### PR TITLE
Adds info to help people get project started

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ For Windows users, you need to install Git on your machine (see https://windows.
 
 Create an empty directory, then download the code from https://github.com/doconix/island.  You don't need a password to download the code, but you won't be able to commit changes until you are granted rights (see Dr. Albrecht).
 
+## Initialize the Database
+
+Run the `create_debugging_data.py` script located in `theCproject` folder. This will populate the database with the minimum amount of information needed to make the site fully functional.
+
 # Committing Your Changes
 
 Before working, always pull the most recent changes from GitHub: `git pull origin master`.

--- a/forum/templates/thread.html
+++ b/forum/templates/thread.html
@@ -1,4 +1,5 @@
 <%inherit file="base_template.htm" />
+<%! import urllib, hashlib %>
 
 <%block name="page_title">${ thread.topic.title | h } &mdash; Island</%block>
 
@@ -45,6 +46,9 @@
         </div><!-- comment_container_left_top -->
         
         <div class="comment_container_left_bottom">
+          <a href="https://en.gravatar.com/">
+            <img src="${'http://www.gravatar.com/avatar/' + hashlib.md5(request.user.email.lower().encode('utf-8')).hexdigest()}" height="60x"/>
+          </a>
           <div>Joined: ${ comment.user.date_joined.strftime('%b %Y') }</div>
           <div>Points: ${ comment.user.total_points }</div>
         </div><!-- comment_container_left_bottom -->

--- a/homepage/templates/base_template.htm
+++ b/homepage/templates/base_template.htm
@@ -3,6 +3,7 @@
 ## set up a StaticRenderer object to enable the CSS/JS automatic inclusion magic.
 <%! from django_mako_plus.controller import static_files %>
 <%! from forum import models as fmod %>
+<%! import urllib, hashlib %>
 <%  static_renderer = static_files.StaticRenderer(self) %>
 
 <!DOCTYPE html>
@@ -85,7 +86,9 @@
     <div id="right_bar">
       %if request.user.is_authenticated():
         <header style="height: 115px;">
-            <img src="/static/homepage/media/image/ironman.jpeg" height="40px"/>
+            <a href="https://en.gravatar.com/">
+              <img src="${'http://www.gravatar.com/avatar/' + hashlib.md5(request.user.email.lower().encode('utf-8')).hexdigest()}" height="40px"/>
+            </a>
             <div class="btn btn-default" style="text-align: left; cursor: initial;">
               ${request.user.username}
               <br/>

--- a/theCproject/create_debugging_data.py
+++ b/theCproject/create_debugging_data.py
@@ -21,15 +21,15 @@ from forum import models as fmod
 import random, datetime, sys
 
 # add a few test users
-# for info in [
-#   ( 'user1', 'doconix@gmail.com', 'Conan2 Albrecht' ),
-#   ( 'user2', 'conan_albrecht@byu.edu', 'Conan3 Albrecht'),
-# ]:
-#   user = hmod.SiteUser()
-#   user.username = info[0]
-#   user.email = info[1]
-#   user.fullname = info[2]
-#   user.save()
+for info in [
+  ( 'user1', 'doconix@gmail.com', 'Conan2 Albrecht' ),
+  ( 'user2', 'conan_albrecht@byu.edu', 'Conan3 Albrecht'),
+]:
+  user = hmod.SiteUser()
+  user.username = info[0]
+  user.email = info[1]
+  user.fullname = info[2]
+  user.save()
 
 # ensure the main user (Conan or Thong) is a staff and superuser
 user = hmod.SiteUser.objects.get(email='ca@byu.edu')

--- a/theCproject/create_debugging_data.py
+++ b/theCproject/create_debugging_data.py
@@ -32,7 +32,7 @@ for info in [
   user.save()
 
 # ensure the main user (Conan or Thong) is a staff and superuser
-user = hmod.SiteUser.objects.get(email='ca@byu.edu')
+user = hmod.SiteUser.objects.get(email='doconix@gmail.com')
 user.is_staff = True
 user.is_superuser = True
 user.save()


### PR DESCRIPTION
I added a blurb to the README to help people know where to find the dummy data script. I also uncommented the section of the script that creates dummy users so that the script doesn't throw errors, and I modified the email of the superuser to avoid errors as well.

It might be a good idea to make the script ask for the users information to create the initial user, but I don't have time for that today.

I also added support for Gravatar images on the profile and on individual threads.
