### PR TITLE
Bug in gravatar thread implementation

### DIFF
--- a/forum/templates/thread.html
+++ b/forum/templates/thread.html
@@ -46,9 +46,6 @@
         </div><!-- comment_container_left_top -->
         
         <div class="comment_container_left_bottom">
-          <a href="https://en.gravatar.com/">
-            <img src="${'http://www.gravatar.com/avatar/' + hashlib.md5(request.user.email.lower().encode('utf-8')).hexdigest()}" height="60x"/>
-          </a>
           <div>Joined: ${ comment.user.date_joined.strftime('%b %Y') }</div>
           <div>Points: ${ comment.user.total_points }</div>
         </div><!-- comment_container_left_bottom -->


### PR DESCRIPTION
I accidentally put the gravatar of the site user in place for every
single profile picture.

I'm removing the gravatar because the email address is not available on
the model for each participant in a thread.