### PR TITLE
Changed new thread default to be IS Core as a temporary fix.

### DIFF
--- a/forum/views/newthread.py
+++ b/forum/views/newthread.py
@@ -61,7 +61,7 @@ class ThreadForm(forms.Form):
         self.initial['topic'] = topic.id
     self.fields['topic'] = forms.ChoiceField(label="Topic:", required=True, choices=choices, widget=lib.widgets.ButtonChoiceWidget())
     if not self.initial.get('topic'):
-      self.initial['topic'] = choices[0][0]
+      self.initial['topic'] = choices[2][0]
       
   def clean_file1(self):
     if self.cleaned_data['file1']:


### PR DESCRIPTION
As we try to restart Island (and as we saw last semester) there is too much noise being generated from new students who don't know to pick the "IS Core" topic when creating a new thread, resulting in homework assignments ending up in the general group and decreasing the value for many. 

This change is a hack, temporary, ugly, but hopefully is a stop gap to keep people from completely dropping the Island. :) It simply changes the default on new threads to be IS Core, based on PK and sort_order. Veterans will understand the lay of the land and (should) have the sense to change it to Tech or Non-tech. New students will most likely make fewer mistakes. 

Eventually this should be modified to probably *not* have a default option preselected, to force the user to think about what group to place it in. But until then, let's get this in place.